### PR TITLE
Feat/new seeds

### DIFF
--- a/task_examples/generate_volume_element.yml
+++ b/task_examples/generate_volume_element.yml
@@ -12,6 +12,7 @@ tasks:
     method: random
     software: damask
     base:
+      size: [1, 1, 1]
       grid_size: [16, 16, 16]
       num_grains: 3
     output_map_options:
@@ -28,7 +29,6 @@ tasks:
     software: damask
     context: example_1
     base:
-      size: [1, 1, 1]
       homog_label: SX
 
   # Example 2: Like example 1, but specify do two additional modifications to the volume
@@ -40,7 +40,6 @@ tasks:
     software: damask
     context: example_2
     base:
-      size: [1, 1, 1]
       homog_label: SX
       scale_morphology: [1.5, 1, 1]     # optional
       buffer_phase_size: [8, 0, 0]      # optional, this is voxels to add to one face
@@ -68,7 +67,6 @@ tasks:
     software: damask
     context: example_4
     base:
-      size: [1, 1, 1]
       homog_label: SX
       orientations:
         type: quat

--- a/task_examples/test_DAMASK_P_constant.yml
+++ b/task_examples/test_DAMASK_P_constant.yml
@@ -8,6 +8,7 @@ tasks:
     method: random
     software: damask
     base:
+      size: [1, 1, 1]
       grid_size: [4, 4, 4]
       num_grains: 1
     output_map_options:
@@ -17,7 +18,6 @@ tasks:
     method: random_voronoi_from_orientations
     software: damask
     base:
-      size: [1, 1, 1]
       homog_label: SX
     sequences:
       - name: orientations

--- a/task_schemas.yml
+++ b/task_schemas.yml
@@ -251,7 +251,8 @@
       implementations:
         - name: damask
           inputs:
-            - grid_size
+            - name: grid_size
+              ignore_dependency_from: ['generate_volume_element']
           outputs:
             - microstructure_seeds
           command_files:
@@ -283,6 +284,7 @@
             - phase_label
             - name: grid_size
               default: null
+              ignore_dependency_from: ['generate_volume_element']
             - name: orientation_coordinate_system
               default: null
           outputs:

--- a/task_schemas.yml
+++ b/task_schemas.yml
@@ -246,7 +246,7 @@
               stderr: stderr.log
               options: 
                 - [-N, num_grains]
-                - [-g, grid_size]       
+                - [-g, grid_size]
           output_map:
             - files: 
                 - name: <<positions>>
@@ -256,6 +256,20 @@
                   default: null
                 - name: phase_label
               output: microstructure_seeds
+    - name: random_NEW
+      inputs:
+        - size
+        - num_grains
+      implementations:
+        - name: damask
+          inputs:
+            - phase_label
+            - name: grid_size
+              default: null
+            - name: orientation_coordinate_system
+              default: null
+          outputs:
+            - microstructure_seeds
 
 - name: load_microstructure
   outputs:
@@ -463,10 +477,12 @@
         - name: damask
           inputs:
             - name: microstructure_seeds
-            - name: size
+            - name: grid_size
             - name: homog_label
             - name: scale_morphology
               default: null
+            - name: scale_update_size
+              default: true
             - name: buffer_phase_size
               default: null
             - name: buffer_phase_label
@@ -517,10 +533,12 @@
         functions).
       inputs: 
         - name: microstructure_seeds
-        - name: size
+        - name: grid_size
         - name: homog_label                
         - name: scale_morphology
           default: null
+        - name: scale_update_size
+          default: true
         - name: buffer_phase_size
           default: null
         - name: buffer_phase_label

--- a/task_schemas.yml
+++ b/task_schemas.yml
@@ -232,10 +232,12 @@
   methods:
     - name: random
       inputs:
-        - grid_size
+        - size
         - num_grains
       implementations:
         - name: damask
+          inputs:
+            - grid_size
           outputs:
             - microstructure_seeds
           command_files:
@@ -247,6 +249,7 @@
               options: 
                 - [-N, num_grains]
                 - [-g, grid_size]
+                - [-s, size]
           output_map:
             - files: 
                 - name: <<positions>>

--- a/work_in_progress/rolling_sim-multi_size.yml
+++ b/work_in_progress/rolling_sim-multi_size.yml
@@ -1,0 +1,157 @@
+name: rolling_sim-multi_size
+archive: dropbox
+tasks:
+
+  - name: generate_microstructure_seeds
+    method: random_NEW
+    software: damask
+    context: scale_1
+    repeats: 6
+    base:
+      size: [1, 1, 1]
+      grid_size: [16, 16, 16]
+      num_grains: 4096
+      phase_label: IF_steel
+
+  - name: generate_microstructure_seeds
+    method: random_NEW
+    software: damask
+    context: scale_1+2
+    repeats: 3
+    base:
+      size: [1, 1, 1]
+      grid_size: [16, 16, 16]
+      num_grains: 4096
+      phase_label: IF_steel
+
+  - name: generate_microstructure_seeds
+    method: random_NEW
+    software: damask
+    context: scale_2+3
+    base:
+      size: [1, 1, 1]
+      grid_size: [32, 32, 32]
+      num_grains: 4096
+      phase_label: IF_steel
+
+#--------------------------------------
+
+  - name: generate_volume_element
+    method: random_voronoi
+    software: damask
+    context: scale_1
+    base:
+      grid_size: [16, 16, 16]
+      homog_label: SX
+
+  - name: generate_volume_element
+    method: random_voronoi
+    software: damask
+    context: scale_1+2
+    base:
+      homog_label: SX
+    sequences:
+      - name: grid_size
+        vals:
+          - [16, 16, 16]
+          - [32, 32, 32]
+
+  - name: generate_volume_element
+    method: random_voronoi
+    software: damask
+    context: scale_2+3
+    base:
+      homog_label: SX
+    sequences:
+      - name: grid_size
+        vals:
+          - [32, 32, 32]
+          - [64, 64, 64]
+
+#--------------------------------------
+
+  - name: visualise_volume_element
+    method: VTK
+    software: damask
+    contexts: [scale_1, scale_1+2, scale_2+3]
+
+  - name: generate_load_case
+    method: plane_strain
+    software: formable
+    base:
+      total_times: [3]
+      num_increments: [300]
+      target_strain_rates: [-0.1]
+      dump_frequency: [2]
+      directions: [zy]
+
+  - name: simulate_volume_element_loading
+    method: CP_FFT
+    software: DAMASK
+    contexts: [scale_1, scale_1+2, scale_2+3]
+    run_options:
+      num_cores: 4
+    output_map_options:
+      operations:
+        - name: add_stress_Cauchy
+          args: {P: P, F: F}
+          opts: { }
+        - name: add_strain
+          args: {F: F, t: U, m: 0}
+          opts: { }
+      incremental_data:
+        - name: vol_avg_stress
+          path: constituent/1_IF_steel/generic/sigma
+          transforms: [mean_along_axes: 1]
+        - name: vol_avg_strain
+          path: constituent/1_IF_steel/generic/epsilon_U^0(F)
+          transforms: [mean_along_axes: 1]
+        - name: orientations
+          path: phase/1_IF_steel/generic/O
+          increments: 25
+    base:
+      homogenization_schemes:
+        SX:
+          mech:
+            type: none
+      phases:
+        IF_steel:
+          elasticity:
+            type: hooke
+            C_11: 233.3e9
+            C_12: 135.5e9
+            C_44: 118.0e9
+          generic:
+            output: [F, P, O]
+          lattice: bcc
+          plasticity:
+            type: phenopowerlaw 
+            N_sl: [12, 12]
+            N_tw: [0]
+            n_sl: 20
+            a_sl: 2.25
+            atol_xi: 1.0
+            dot_gamma_0_sl: 0.001
+            xi_0_sl: [95.e6, 97.e6]
+            xi_inf_sl: [222.e6, 412.7e6]
+            h_0_sl_sl: 1.e9
+            h_sl_sl: [1, 1, 1.4, 1.4, 1.4, 1.4]
+      numerics:
+        grid:
+          itmin: 2
+          itmax: 100
+          derivative: FWBW_difference
+          # petsc_options: -snes_type newtonls -snes_mf -snes_ksp_ew -ksp_type fgmres
+
+  # - name: visualise_volume_element_response
+  #   method: texture_pole_figure
+  #   software: mtex
+  #   base:
+  #     crystal_symmetry: cubic
+  #     pole_figure_directions:
+  #       - [0, 0, 1]
+  #       - [1, 0, 1]
+  #       - [1, 1, 1]
+  #   sequences:
+  #     - name: increment
+  #       vals: [0, 1, 2, 3, 4, 5, 6]

--- a/workflows/by_software/DAMASK/nesting_1.yml
+++ b/workflows/by_software/DAMASK/nesting_1.yml
@@ -9,6 +9,8 @@ tasks:
   - name: generate_microstructure_seeds
     method: random
     software: damask
+    base:
+      size: [1, 1, 1]
     sequences:
       - name: grid_size
         nest_idx: 0

--- a/workflows/by_software/DAMASK/nesting_2.yml
+++ b/workflows/by_software/DAMASK/nesting_2.yml
@@ -9,6 +9,8 @@ tasks:
   - name: generate_microstructure_seeds
     method: random
     software: damask
+    base:
+      size: [1, 1, 1]
     sequences:
       - name: grid_size
         nest_idx: 0

--- a/workflows/fit_yield_function.yml
+++ b/workflows/fit_yield_function.yml
@@ -9,6 +9,7 @@ tasks:
     method: random
     software: damask
     base:
+      size: [1, 1, 1]
       grid_size: [4, 4, 4]
       num_grains: 3
     output_map_options:
@@ -18,7 +19,6 @@ tasks:
     method: random_voronoi
     software: damask
     base:
-      size: [1, 1, 1]
       homog_label: SX
 
   - name: visualise_volume_element

--- a/workflows/single_crystal_parameter_fitting.yml
+++ b/workflows/single_crystal_parameter_fitting.yml
@@ -12,6 +12,7 @@ tasks:
     method: random
     software: damask
     base:
+      size: [1, 1, 1]
       grid_size: [32, 32, 32]
       num_grains: 2000
     output_map_options:
@@ -21,7 +22,6 @@ tasks:
     method: random_voronoi
     software: damask
     base:
-      size: [1, 1, 1]
       homog_label: SX
       scale_morphology: [1.5, 1, 1]
 

--- a/workflows/uniaxial_tensile_test_sim.yml
+++ b/workflows/uniaxial_tensile_test_sim.yml
@@ -10,6 +10,7 @@ tasks:
     method: random
     software: damask
     base:
+      size: [1, 1, 1]
       grid_size: [4, 4, 4]
       num_grains: 3
     output_map_options:
@@ -19,7 +20,6 @@ tasks:
     method: random_voronoi
     software: damask
     base:
-      size: [1, 1, 1]
       homog_label: SX
 
   - name: visualise_volume_element


### PR DESCRIPTION
Changes to task schema and example workflow to accompany LightForm-group/matflow-damask#6. Task schema for `generate_microstructure_seeds`
- `random` - `size` and `grid_size` are required
- `random_NEW` - `size` is required and `grid_size` is optional but must be explicitly set to null currently or task dependence cannot be resolved by matflow
Task schema for `generate_volume_element`-`random_voronoi` and `random_voronoi_from_orientations` - `size` is not a parameter and passed through the seeds dictionary, `grid_size` is now required